### PR TITLE
feat/#11: JPA Auditing 적용

### DIFF
--- a/src/main/java/com/seasonthon/YEIN/YeinApplication.java
+++ b/src/main/java/com/seasonthon/YEIN/YeinApplication.java
@@ -2,8 +2,10 @@ package com.seasonthon.YEIN;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")
 public class YeinApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/seasonthon/YEIN/global/entity/BaseAuditEntity.java
+++ b/src/main/java/com/seasonthon/YEIN/global/entity/BaseAuditEntity.java
@@ -1,0 +1,33 @@
+package com.seasonthon.YEIN.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseAuditEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private Long createdBy;
+
+    @LastModifiedBy
+    private Long modifiedBy;
+}

--- a/src/main/java/com/seasonthon/YEIN/global/entity/BaseEntity.java
+++ b/src/main/java/com/seasonthon/YEIN/global/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.seasonthon.YEIN.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/seasonthon/YEIN/global/jpa/AuditorAwareImpl.java
+++ b/src/main/java/com/seasonthon/YEIN/global/jpa/AuditorAwareImpl.java
@@ -1,0 +1,30 @@
+package com.seasonthon.YEIN.global.jpa;
+
+import com.seasonthon.YEIN.global.security.CustomUserDetails;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component("auditorAwareImpl")
+public class AuditorAwareImpl implements AuditorAware<Long> {
+
+    @Override
+    public Optional<Long> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())) {
+            return Optional.empty();
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof CustomUserDetails userDetails) {
+            Long userId = userDetails.getUserId();
+            return Optional.of(userId);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/seasonthon/YEIN/global/security/CustomUserDetails.java
+++ b/src/main/java/com/seasonthon/YEIN/global/security/CustomUserDetails.java
@@ -1,0 +1,49 @@
+package com.seasonthon.YEIN.global.security;
+
+import com.seasonthon.YEIN.user.domain.RoleType;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.*;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Long userId;
+    private final String username;
+    private final String password;
+    private final RoleType roleType;
+    private final Set<GrantedAuthority> authorities;
+
+    public CustomUserDetails(Collection<? extends GrantedAuthority> authorities, String username,
+                             RoleType roleType, Long userId) {
+
+        this.authorities = (authorities != null)
+                ? Collections.unmodifiableSet(new LinkedHashSet<>(this.sortAuthorities(authorities)))
+                : Collections.unmodifiableSet(new LinkedHashSet<>(AuthorityUtils.NO_AUTHORITIES));
+        this.userId = userId;
+        this.username = username;
+        this.password = null;  // 소셜로그인이므로 null
+        this.roleType = roleType;
+    }
+
+    private Set<GrantedAuthority> sortAuthorities(Collection<? extends GrantedAuthority> authorities) {
+        SortedSet<GrantedAuthority> sortedAuthorities = new TreeSet<>(Comparator.comparing(GrantedAuthority::getAuthority));
+        sortedAuthorities.addAll(authorities);
+        return sortedAuthorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/seasonthon/YEIN/user/domain/RoleType.java
+++ b/src/main/java/com/seasonthon/YEIN/user/domain/RoleType.java
@@ -1,0 +1,14 @@
+package com.seasonthon.YEIN.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoleType {
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN"),
+    GUEST("ROLE_GUEST");
+
+    private final String key;
+}

--- a/src/main/java/com/seasonthon/YEIN/user/domain/User.java
+++ b/src/main/java/com/seasonthon/YEIN/user/domain/User.java
@@ -1,0 +1,58 @@
+package com.seasonthon.YEIN.user.domain;
+
+import com.seasonthon.YEIN.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Table(name = "users")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "nickname")
+    private String nickname;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role_type", nullable = false)
+    private RoleType roleType;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @Builder
+    public User(String email, String nickname,  String profileImageUrl, RoleType roleType, LocalDateTime lastLoginAt) {
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.roleType = roleType;
+        this.lastLoginAt = lastLoginAt;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateProfileImage(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void markLogin() {
+        this.lastLoginAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/seasonthon/YEIN/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/seasonthon/YEIN/user/domain/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.seasonthon.YEIN.user.domain.repository;
+
+import com.seasonthon.YEIN.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
# 구현 내용
- JPA Auditing을 이용해 생성일시, 수정일시, 생성자, 수정자를 간편하게 사용할 수 있도록 한다.