### PR TITLE
feat/#39: 프론트 배포 주소에 맞게 cors 설정

### DIFF
--- a/src/main/java/com/seasonthon/YEIN/global/security/SecurityConfig.java
+++ b/src/main/java/com/seasonthon/YEIN/global/security/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173", "https://yein.vercel.app",
-                "http://localhost:3000", "https://yein-frontend.vercel.app"));
+                "http://localhost:3000", "https://2025-seasonthon-team-16-fe.vercel.app"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "RefreshToken", "id_token", "Content-Type"));
         configuration.setExposedHeaders(Arrays.asList("Authorization", "RefreshToken"));


### PR DESCRIPTION
# 구현 내용
- 프론트 배포 주소에 맞게 cors 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved cross-origin (CORS) errors when accessing the app from the new frontend URL, ensuring pages load correctly and API actions (login, data fetches) work reliably at https://2025-seasonthon-team-16-fe.vercel.app.

* **Chores**
  * Updated the approved frontend domain for cross-origin requests to match the latest deployment and removed the outdated domain to prevent intermittent access issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->