### PR TITLE
feat/#46: 필사 갤러리 기분 태그 및 제목 추가

### DIFF
--- a/src/main/java/com/seasonthon/YEIN/ai/api/HandwritingAnalysisController.java
+++ b/src/main/java/com/seasonthon/YEIN/ai/api/HandwritingAnalysisController.java
@@ -3,17 +3,22 @@ package com.seasonthon.YEIN.ai.api;
 import com.seasonthon.YEIN.ai.api.dto.response.AnalysisCriteriaResponse;
 import com.seasonthon.YEIN.ai.api.dto.response.HandwritingAnalysisResponse;
 import com.seasonthon.YEIN.ai.application.HandwritingAnalysisService;
+import com.seasonthon.YEIN.gallery.api.dto.request.GalleryUploadRequest;
+import com.seasonthon.YEIN.gallery.domain.MoodTag;
 import com.seasonthon.YEIN.global.code.dto.ApiResponse;
 import com.seasonthon.YEIN.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Set;
 
 @Tag(name = "필사 이미지 분석 API", description = "AI를 사용하여 필사 이미지 분석 및 점수 평가")
 @RestController
@@ -29,9 +34,11 @@ public class HandwritingAnalysisController {
     public ResponseEntity<ApiResponse<HandwritingAnalysisResponse>> analyzeHandwriting(
             @Parameter(description = "분석할 손글씨 이미지 파일 (JPG, PNG, WEBP 지원, 최대 10MB)", required = true)
             @RequestParam("image") MultipartFile image,
+            @Parameter(description = "갤러리 업로드 정보", required = true)
+            @Valid @RequestPart("data") GalleryUploadRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        HandwritingAnalysisResponse response = analysisService.analyzeHandwriting(image, userDetails.getUserId());
+        HandwritingAnalysisResponse response = analysisService.analyzeHandwriting(image, request, userDetails.getUserId());
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 

--- a/src/main/java/com/seasonthon/YEIN/ai/application/HandwritingAnalysisService.java
+++ b/src/main/java/com/seasonthon/YEIN/ai/application/HandwritingAnalysisService.java
@@ -6,6 +6,7 @@ import com.google.genai.types.Content;
 import com.google.genai.types.GenerateContentResponse;
 import com.google.genai.types.Part;
 import com.seasonthon.YEIN.ai.api.dto.response.HandwritingAnalysisResponse;
+import com.seasonthon.YEIN.gallery.api.dto.request.GalleryUploadRequest;
 import com.seasonthon.YEIN.gallery.domain.Gallery;
 import com.seasonthon.YEIN.gallery.domain.repository.GalleryRepository;
 import com.seasonthon.YEIN.global.code.status.ErrorStatus;
@@ -38,7 +39,7 @@ public class HandwritingAnalysisService {
     );
     private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
-    public HandwritingAnalysisResponse analyzeHandwriting(MultipartFile image, Long userId) {
+    public HandwritingAnalysisResponse analyzeHandwriting(MultipartFile image, GalleryUploadRequest request, Long userId) {
         String imageUrl = null;
 
         try {
@@ -52,7 +53,7 @@ public class HandwritingAnalysisService {
             HandwritingAnalysisResponse response = performAIAnalysis(image);
 
             User user = getUser(userId);
-            saveToGallery(user, imageUrl, response);
+            saveToGallery(user, imageUrl, request, response);
             return response;
 
         } catch (Exception e) {
@@ -205,11 +206,13 @@ public class HandwritingAnalysisService {
         }
     }
 
-    private void saveToGallery(User user, String imageUrl, HandwritingAnalysisResponse response) {
+    private void saveToGallery(User user, String imageUrl, GalleryUploadRequest request, HandwritingAnalysisResponse response) {
         try {
             Gallery gallery = Gallery.builder()
                     .user(user)
                     .imageUrl(imageUrl)
+                    .title(request.title())
+                    .moodTags(request.moodTags())
                     .alignmentScore(response.alignmentScore())
                     .spacingScore(response.spacingScore())
                     .consistencyScore(response.consistencyScore())

--- a/src/main/java/com/seasonthon/YEIN/gallery/api/GalleryController.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/api/GalleryController.java
@@ -3,6 +3,7 @@ package com.seasonthon.YEIN.gallery.api;
 import com.seasonthon.YEIN.gallery.api.dto.response.GalleryDetailResponse;
 import com.seasonthon.YEIN.gallery.api.dto.response.GalleryResponse;
 import com.seasonthon.YEIN.gallery.application.GalleryService;
+import com.seasonthon.YEIN.gallery.domain.MoodTag;
 import com.seasonthon.YEIN.global.code.dto.ApiResponse;
 import com.seasonthon.YEIN.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,6 +16,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
 
 @RestController
 @RequestMapping("/api/galleries")

--- a/src/main/java/com/seasonthon/YEIN/gallery/api/dto/request/GalleryUploadRequest.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/api/dto/request/GalleryUploadRequest.java
@@ -1,0 +1,20 @@
+package com.seasonthon.YEIN.gallery.api.dto.request;
+
+import com.seasonthon.YEIN.gallery.domain.MoodTag;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.Set;
+
+@Schema(description = "갤러리 업로드 요청")
+public record GalleryUploadRequest(
+
+        @Schema(description = "필사 제목", example = "오늘의 독서 필사")
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 100, message = "제목은 100자 이하로 입력해주세요")
+        String title,
+
+        @Schema(description = "기분 태그 (복수 선택 가능)", example = "[\"CALM\", \"FOCUSED\"]")
+        Set<MoodTag> moodTags
+) {}

--- a/src/main/java/com/seasonthon/YEIN/gallery/api/dto/response/GalleryDetailResponse.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/api/dto/response/GalleryDetailResponse.java
@@ -1,14 +1,22 @@
 package com.seasonthon.YEIN.gallery.api.dto.response;
 
+import com.seasonthon.YEIN.gallery.domain.MoodTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 @Schema(description = "갤러리 상세 정보 응답")
 public record GalleryDetailResponse(
 
         @Schema(description = "갤러리 ID", example = "1")
         Long id,
+
+        @Schema(description = "필사 제목", example = "오늘의 독서 필사")
+        String title,
+
+        @Schema(description = "기분 태그", example = "[\"CALM\", \"FOCUSED\"]")
+        Set<MoodTag> moodTags,
 
         @Schema(description = "필사 이미지 S3 URL", example = "https://bucket-name.s3.region.amazonaws.com/uploads/image123.jpg")
         String imageUrl,

--- a/src/main/java/com/seasonthon/YEIN/gallery/api/dto/response/GalleryResponse.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/api/dto/response/GalleryResponse.java
@@ -1,14 +1,22 @@
 package com.seasonthon.YEIN.gallery.api.dto.response;
 
+import com.seasonthon.YEIN.gallery.domain.MoodTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 @Schema(description = "갤러리 목록 응답")
 public record GalleryResponse(
 
         @Schema(description = "갤러리 ID", example = "1")
         Long id,
+
+        @Schema(description = "필사 제목", example = "오늘의 독서 필사")
+        String title,
+
+        @Schema(description = "기분 태그", example = "[\"CALM\", \"FOCUSED\"]")
+        Set<MoodTag> moodTags,
 
         @Schema(description = "필사 이미지 S3 URL", example = "https://bucket-name.s3.region.amazonaws.com/uploads/image123.jpg")
         String imageUrl,

--- a/src/main/java/com/seasonthon/YEIN/gallery/application/GalleryService.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/application/GalleryService.java
@@ -3,6 +3,7 @@ package com.seasonthon.YEIN.gallery.application;
 import com.seasonthon.YEIN.gallery.api.dto.response.GalleryDetailResponse;
 import com.seasonthon.YEIN.gallery.api.dto.response.GalleryResponse;
 import com.seasonthon.YEIN.gallery.domain.Gallery;
+import com.seasonthon.YEIN.gallery.domain.MoodTag;
 import com.seasonthon.YEIN.gallery.domain.repository.GalleryRepository;
 import com.seasonthon.YEIN.global.code.status.ErrorStatus;
 import com.seasonthon.YEIN.global.exception.GeneralException;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -65,6 +67,8 @@ public class GalleryService {
     private GalleryResponse toGalleryResponse(Gallery gallery) {
         return new GalleryResponse(
                 gallery.getId(),
+                gallery.getTitle(),
+                gallery.getMoodTags(),
                 gallery.getImageUrl(),
                 gallery.getTotalScore(),
                 gallery.getCreatedAt()
@@ -74,6 +78,8 @@ public class GalleryService {
     private GalleryDetailResponse toGalleryDetailResponse(Gallery gallery) {
         return new GalleryDetailResponse(
                 gallery.getId(),
+                gallery.getTitle(),
+                gallery.getMoodTags(),
                 gallery.getImageUrl(),
                 gallery.getAlignmentScore(),
                 gallery.getSpacingScore(),

--- a/src/main/java/com/seasonthon/YEIN/gallery/domain/Gallery.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/domain/Gallery.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.HashSet;
+import java.util.Set;
+
 @Entity
 @Table(name = "galleries")
 @Getter
@@ -49,10 +52,17 @@ public class Gallery extends BaseEntity {
     @Column(name = "detailed_analysis", columnDefinition = "TEXT")
     private String detailedAnalysis;
 
+    @Column(name = "title")
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mood_tags")
+    private Set<MoodTag> moodTags = new HashSet<>();
+
     @Builder
     public Gallery(User user, String imageUrl, Integer alignmentScore, Integer spacingScore,
                    Integer consistencyScore, Integer lengthScore, Integer totalScore,
-                   String feedback, String strengths, String detailedAnalysis) {
+                   String feedback, String strengths, String detailedAnalysis, String title, Set<MoodTag> moodTags) {
         this.user = user;
         this.imageUrl = imageUrl;
         this.alignmentScore = alignmentScore;
@@ -63,5 +73,7 @@ public class Gallery extends BaseEntity {
         this.feedback = feedback;
         this.strengths = strengths;
         this.detailedAnalysis = detailedAnalysis;
+        this.title = title;
+        this.moodTags = moodTags != null ? moodTags : new HashSet<>();
     }
 }

--- a/src/main/java/com/seasonthon/YEIN/gallery/domain/MoodTag.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/domain/MoodTag.java
@@ -1,0 +1,16 @@
+package com.seasonthon.YEIN.gallery.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum MoodTag {
+    CALM("평온"),
+    FOCUSED("집중"),
+    DEPRESSED("우울");
+
+    private final String description;
+
+    MoodTag(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/seasonthon/YEIN/gallery/domain/repository/GalleryRepository.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/domain/repository/GalleryRepository.java
@@ -1,6 +1,7 @@
 package com.seasonthon.YEIN.gallery.domain.repository;
 
 import com.seasonthon.YEIN.gallery.domain.Gallery;
+import com.seasonthon.YEIN.gallery.domain.MoodTag;
 import com.seasonthon.YEIN.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.Set;
 
 public interface GalleryRepository extends JpaRepository<Gallery, Long> {
 


### PR DESCRIPTION
# 구현 내용
- 필사 갤러리 기분 태그 및 제목 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 손글씨 분석 업로드에 이미지와 함께 제목 및 기분 태그를 전송할 수 있습니다.
  * 갤러리 목록/상세 화면 응답에 제목과 기분 태그가 포함되어 더 풍부한 정보 확인이 가능합니다.
  * 지원 기분 태그: 평온(CALM), 집중(FOCUSED), 우울(DEPRESSED).
  * 요청 형식이 멀티파트(이미지 + 데이터)로 확장되었습니다. 기존 단일 이미지 업로드를 사용 중인 경우 클라이언트 요청 구성을 업데이트하세요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->