### PR TITLE
fix/#49: JPA Set 매핑 오류 수정 및 Multipart 파일 바인딩 개선

### DIFF
--- a/src/main/java/com/seasonthon/YEIN/ai/api/HandwritingAnalysisController.java
+++ b/src/main/java/com/seasonthon/YEIN/ai/api/HandwritingAnalysisController.java
@@ -33,7 +33,7 @@ public class HandwritingAnalysisController {
     @PostMapping(value = "/analyze", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<HandwritingAnalysisResponse>> analyzeHandwriting(
             @Parameter(description = "분석할 손글씨 이미지 파일 (JPG, PNG, WEBP 지원, 최대 10MB)", required = true)
-            @RequestParam("image") MultipartFile image,
+            @RequestPart("image") MultipartFile image,
             @Parameter(description = "갤러리 업로드 정보", required = true)
             @Valid @RequestPart("data") GalleryUploadRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/com/seasonthon/YEIN/gallery/domain/Gallery.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/domain/Gallery.java
@@ -55,8 +55,10 @@ public class Gallery extends BaseEntity {
     @Column(name = "title")
     private String title;
 
+    @ElementCollection(targetClass = MoodTag.class, fetch = FetchType.EAGER)
+    @CollectionTable(name = "gallery_mood_tags", joinColumns = @JoinColumn(name = "gallery_id"))
+    @Column(name = "mood_tag", nullable = false)
     @Enumerated(EnumType.STRING)
-    @Column(name = "mood_tags")
     private Set<MoodTag> moodTags = new HashSet<>();
 
     @Builder

--- a/src/main/java/com/seasonthon/YEIN/post/api/PostController.java
+++ b/src/main/java/com/seasonthon/YEIN/post/api/PostController.java
@@ -33,7 +33,7 @@ public class PostController {
     public ResponseEntity<ApiResponse<PostResponse>> createPost(
             @RequestPart("data") @Valid PostRequest request,
             @Parameter(description = "이미지 파일 (선택사항)", schema = @Schema(type = "string", format = "binary"))
-            @RequestParam(required = false) MultipartFile image,
+            @RequestPart(value = "image", required = false) MultipartFile image,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         PostResponse response = postService.createPost(request, userDetails.getUserId(), image);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -72,7 +72,7 @@ public class PostController {
             @PathVariable Long postId,
             @RequestPart("data") @Valid PostRequest request,
             @Parameter(description = "이미지 파일 (선택사항)", schema = @Schema(type = "string", format = "binary"))
-            @RequestParam(required = false) MultipartFile image,
+            @RequestPart(value = "image", required = false) MultipartFile image,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         PostResponse response = postService.updatePost(postId, request, userDetails.getUserId(), image);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));


### PR DESCRIPTION
# 수정 내용
- JPA Set 매핑 오류 수정 및 Multipart 파일 바인딩 개선

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 리팩터
  - 손글씨 분석과 게시글 생성/수정 API의 이미지 업로드 형식을 멀티파트 파트(이름: image)로 통일했습니다. 클라이언트는 멀티파트 요청으로 이미지를 전송해야 합니다.
- 잡무
  - 갤러리의 무드 태그 저장 방식을 개선하여 태그가 안정적으로 조회·관리되도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->