### PR TITLE
feat/#53: 필사 갤러리 삭제 API 구현

### DIFF
--- a/src/main/java/com/seasonthon/YEIN/gallery/api/GalleryController.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/api/GalleryController.java
@@ -3,7 +3,6 @@ package com.seasonthon.YEIN.gallery.api;
 import com.seasonthon.YEIN.gallery.api.dto.response.GalleryDetailResponse;
 import com.seasonthon.YEIN.gallery.api.dto.response.GalleryResponse;
 import com.seasonthon.YEIN.gallery.application.GalleryService;
-import com.seasonthon.YEIN.gallery.domain.MoodTag;
 import com.seasonthon.YEIN.global.code.dto.ApiResponse;
 import com.seasonthon.YEIN.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,8 +15,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Set;
 
 @RestController
 @RequestMapping("/api/galleries")
@@ -67,5 +64,16 @@ public class GalleryController {
 
         GalleryDetailResponse gallery = galleryService.getGalleryDetail(galleryId, userDetails.getUserId());
         return ResponseEntity.ok(ApiResponse.onSuccess(gallery));
+    }
+
+    @DeleteMapping("/{galleryId}")
+    @Operation(summary = "필사 갤러리 삭제", description = "작성자 본인만 필사 갤러리를 삭제할 수 있습니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteGallery(
+            @Parameter(description = "삭제할 갤러리 ID", example = "1")
+            @PathVariable Long galleryId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        galleryService.deleteGallery(galleryId, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
     }
 }


### PR DESCRIPTION
# 구현 내용
- 필사 갤러리 삭제 API 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 필사 갤러리 삭제 기능 추가: 인증된 사용자가 자신의 갤러리를 ID로 삭제할 수 있습니다.
  - 삭제 시 연결된 이미지 파일도 스토리지에서 함께 제거되어 저장 공간이 정리됩니다.
  - 성공 시 표준 응답 형식으로 결과를 반환합니다.

- 기타
  - 사용되지 않는 임포트를 정리하여 코드 품질을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->