### PR TITLE
feat/#62: 사용자가 스크랩한 게시글 조회

### DIFF
--- a/src/main/java/com/seasonthon/YEIN/post/api/ScrapController.java
+++ b/src/main/java/com/seasonthon/YEIN/post/api/ScrapController.java
@@ -3,10 +3,14 @@ package com.seasonthon.YEIN.post.api;
 import com.seasonthon.YEIN.global.code.dto.ApiResponse;
 import com.seasonthon.YEIN.global.code.status.SuccessStatus;
 import com.seasonthon.YEIN.global.security.CustomUserDetails;
+import com.seasonthon.YEIN.post.api.dto.response.PostListResponse;
 import com.seasonthon.YEIN.post.application.ScrapService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -26,5 +30,18 @@ public class ScrapController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         boolean isScraped = scrapService.toggleScrap(userDetails.getUserId(), postId);
         return ResponseEntity.ok(ApiResponse.onSuccess(isScraped));
+    }
+
+    @GetMapping("/posts")
+    @Operation(summary = "스크랩한 게시글 목록 조회", description = "사용자가 스크랩한 게시글 목록을 조회합니다. 키워드 검색 및 정렬이 가능합니다.")
+    public ResponseEntity<ApiResponse<Page<PostListResponse>>> getScrapedPosts(
+            @Parameter(description = "검색 키워드", example = "행복")
+            @RequestParam(required = false) String keyword,
+            @Parameter(description = "정렬 방식 (latest: 최신순, view:조회수순, scrap: 스크랩수순, like: 추천수순, scrap_date: 스크랩날짜순)", example = "latest")
+            @RequestParam(required = false) String sortBy,
+            @Parameter(description = "페이징 정보") Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Page<PostListResponse> response = scrapService.getScrapedPosts(userDetails.getUserId(), keyword, sortBy, pageable);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 }

--- a/src/main/java/com/seasonthon/YEIN/post/application/ScrapService.java
+++ b/src/main/java/com/seasonthon/YEIN/post/application/ScrapService.java
@@ -2,17 +2,23 @@ package com.seasonthon.YEIN.post.application;
 
 import com.seasonthon.YEIN.global.code.status.ErrorStatus;
 import com.seasonthon.YEIN.global.exception.GeneralException;
+import com.seasonthon.YEIN.post.api.dto.response.PostListResponse;
 import com.seasonthon.YEIN.post.domain.Post;
 import com.seasonthon.YEIN.post.domain.Scrap;
+import com.seasonthon.YEIN.post.domain.repository.LikeRepository;
 import com.seasonthon.YEIN.post.domain.repository.PostRepository;
 import com.seasonthon.YEIN.post.domain.repository.ScrapRepository;
 import com.seasonthon.YEIN.user.domain.User;
 import com.seasonthon.YEIN.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +28,7 @@ public class ScrapService {
     private final ScrapRepository scrapRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final LikeRepository likeRepository;
 
     @Transactional
     public boolean toggleScrap(Long userId, Long postId) {
@@ -45,6 +52,21 @@ public class ScrapService {
             post.incrementScrapCount();
             return true;
         }
+    }
+
+    public Page<PostListResponse> getScrapedPosts(Long userId, String keyword, String sortBy, Pageable pageable) {
+        String sort = (sortBy != null) ? sortBy : "latest";
+        Page<Post> scrapedPosts = scrapRepository.findScrapedPostsByUserIdWithFilter(userId, keyword, sort, pageable);
+
+        // 현재 페이지의 모든 게시글 ID 수집
+        List<Long> postIds = scrapedPosts.getContent().stream()
+                .map(Post::getId)
+                .toList();
+
+        // 사용자가 좋아요한 게시글 ID들 조회 (스크랩은 이미 모두 true)
+        Set<Long> likedPostIds = likeRepository.findLikedPostIdsByUserIdAndPostIds(userId, postIds);
+
+        return scrapedPosts.map(post -> PostListResponse.from(post, true, likedPostIds.contains(post.getId())));
     }
 
     public boolean isScraped(Long userId, Long postId) {

--- a/src/main/java/com/seasonthon/YEIN/post/domain/repository/ScrapRepository.java
+++ b/src/main/java/com/seasonthon/YEIN/post/domain/repository/ScrapRepository.java
@@ -1,6 +1,9 @@
 package com.seasonthon.YEIN.post.domain.repository;
 
+import com.seasonthon.YEIN.post.domain.Post;
 import com.seasonthon.YEIN.post.domain.Scrap;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -22,4 +25,23 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     @Query("SELECT s.post.id FROM Scrap s " +
             "WHERE s.user.id = :userId AND s.post.id IN :postIds")
     Set<Long> findScrapedPostIdsByUserIdAndPostIds(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
+
+    @Query("""
+      SELECT s.post FROM Scrap s
+      WHERE s.user.id = :userId
+      AND (:keyword IS NULL OR
+           s.post.title LIKE CONCAT('%', :keyword, '%') OR
+           s.post.quote LIKE CONCAT('%', :keyword, '%') OR
+           s.post.author LIKE CONCAT('%', :keyword, '%') OR
+           s.post.bookTitle LIKE CONCAT('%', :keyword, '%'))
+      ORDER BY
+          CASE WHEN :sortBy = 'latest' THEN s.post.createdAt END DESC,
+          CASE WHEN :sortBy = 'view' THEN s.post.viewCount END DESC,
+          CASE WHEN :sortBy = 'scrap' THEN s.post.scrapCount END DESC,
+          CASE WHEN :sortBy = 'like' THEN s.post.likeCount END DESC,
+          CASE WHEN :sortBy = 'scrap_date' THEN s.createdAt END DESC,
+          s.createdAt DESC
+      """)
+    Page<Post> findScrapedPostsByUserIdWithFilter(@Param("userId") Long userId, @Param("keyword") String keyword, @Param("sortBy") String sortBy, Pageable pageable);
+
 }


### PR DESCRIPTION
# 구현 내용
- 사용자가 스크랩한 게시글 조회

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 내 스크랩한 게시글을 조회하는 API 추가: 페이지네이션, 키워드 필터링, 정렬(최신순, 조회순, 스크랩순, 좋아요순, 스크랩일자순) 지원
  - 응답에 각 게시글의 스크랩 여부(항상 true)와 좋아요 여부 포함
- Documentation
  - 요청 파라미터에 대한 Swagger 메타데이터 보강으로 API 사용성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->