### PR TITLE
feat/#63: 필사 갤러리 사용자 기분 기쁨 추가

### DIFF
--- a/src/main/java/com/seasonthon/YEIN/gallery/api/dto/request/GalleryUploadRequest.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/api/dto/request/GalleryUploadRequest.java
@@ -15,6 +15,6 @@ public record GalleryUploadRequest(
         @Size(max = 100, message = "제목은 100자 이하로 입력해주세요")
         String title,
 
-        @Schema(description = "기분 태그 (복수 선택 가능)", example = "[\"CALM\", \"FOCUSED\"]")
+        @Schema(description = "기분 태그 (복수 선택 가능)", example = "[\"CALM\", \"JOY\"]")
         Set<MoodTag> moodTags
 ) {}

--- a/src/main/java/com/seasonthon/YEIN/gallery/api/dto/response/GalleryDetailResponse.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/api/dto/response/GalleryDetailResponse.java
@@ -15,7 +15,7 @@ public record GalleryDetailResponse(
         @Schema(description = "필사 제목", example = "오늘의 독서 필사")
         String title,
 
-        @Schema(description = "기분 태그", example = "[\"CALM\", \"FOCUSED\"]")
+        @Schema(description = "기분 태그", example = "[\"CALM\", \"JOY\"]")
         Set<MoodTag> moodTags,
 
         @Schema(description = "필사 이미지 S3 URL", example = "https://bucket-name.s3.region.amazonaws.com/uploads/image123.jpg")

--- a/src/main/java/com/seasonthon/YEIN/gallery/api/dto/response/GalleryResponse.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/api/dto/response/GalleryResponse.java
@@ -15,7 +15,7 @@ public record GalleryResponse(
         @Schema(description = "필사 제목", example = "오늘의 독서 필사")
         String title,
 
-        @Schema(description = "기분 태그", example = "[\"CALM\", \"FOCUSED\"]")
+        @Schema(description = "기분 태그", example = "[\"CALM\", \"JOY\"]")
         Set<MoodTag> moodTags,
 
         @Schema(description = "필사 이미지 S3 URL", example = "https://bucket-name.s3.region.amazonaws.com/uploads/image123.jpg")

--- a/src/main/java/com/seasonthon/YEIN/gallery/domain/MoodTag.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/domain/MoodTag.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum MoodTag {
     CALM("평온"),
-    FOCUSED("집중"),
+    JOY("기쁨"),
     DEPRESSED("우울");
 
     private final String description;


### PR DESCRIPTION
# 구현 내용
- 필사 갤러리 사용자 기분 기쁨 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 무드 태그 “JOY(기쁨)”을 도입하여 “FOCUSED(집중)”을 대체했습니다. 업로드, 필터/검색, 상세 보기 등에서 새로운 태그 선택 및 표시가 적용됩니다.

- 문서
  - API 문서의 예시 값에서 moodTags를 ["CALM", "JOY"]로 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->