### PR TITLE
feat/#66: 필사 갤러리 당일 항목 조회

### DIFF
--- a/src/main/java/com/seasonthon/YEIN/gallery/api/GalleryController.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/api/GalleryController.java
@@ -33,7 +33,7 @@ public class GalleryController {
             @Parameter(description = "페이지 크기", example = "20")
             @RequestParam(defaultValue = "20") int size,
 
-            @Parameter(description = "기간 필터링 옵션: week(최근 7일), month(최근 30일), all(전체 기간, 생략시 기본값)", example = "week")
+            @Parameter(description = "기간 필터링 옵션: today(당일), week(최근 7일), month(최근 30일), all(전체 기간, 생략시 기본값)", example = "week")
             @RequestParam(required = false) String period,
 
             @Parameter(description = "최소 점수 (0-100)", example = "70")

--- a/src/main/java/com/seasonthon/YEIN/gallery/application/GalleryService.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/application/GalleryService.java
@@ -71,6 +71,7 @@ public class GalleryService {
         if (period == null) return null;
 
         return switch (period.toLowerCase()) {
+            case "today" -> LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
             case "week" -> LocalDateTime.now().minusWeeks(1);
             case "month" -> LocalDateTime.now().minusMonths(1);
             case "all" -> null;


### PR DESCRIPTION
# 구현 기능
- 필사 갤러리 당일 항목 조회

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 갤러리 목록 조회에 기간 필터 today(당일) 옵션 추가
  - 오늘 00:00부터 현재까지의 항목만 표시
  - 기존 week/month/all 동작은 그대로 유지

- Documentation
  - OpenAPI 문서의 period 파라미터 설명에 today(당일) 옵션 반영
  - 예시는 기존과 동일하게 week 유지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->