### PR TITLE
feat/#76: 펫 변경 및 이름 변경 API 구현

### DIFF
--- a/src/main/java/com/seasonthon/YEIN/pet/api/PetController.java
+++ b/src/main/java/com/seasonthon/YEIN/pet/api/PetController.java
@@ -2,6 +2,7 @@ package com.seasonthon.YEIN.pet.api;
 
 import com.seasonthon.YEIN.global.code.dto.ApiResponse;
 import com.seasonthon.YEIN.global.security.CustomUserDetails;
+import com.seasonthon.YEIN.pet.api.dto.request.PetNameUpdateRequest;
 import com.seasonthon.YEIN.pet.api.dto.request.PetUpdateRequest;
 import com.seasonthon.YEIN.pet.api.dto.response.PetStatusResponse;
 import com.seasonthon.YEIN.pet.application.PetService;
@@ -30,11 +31,20 @@ public class PetController {
     }
 
     @PatchMapping("/me")
-    @Operation(summary = "내 펫 변경", description = "로그인한 사용자의 펫 종류와 이름을 변경합니다. DEFAULT 타입으로는 변경할 수 없습니다.")
+    @Operation(summary = "내 펫 변경", description = "로그인한 사용자의 펫 종류를 변경합니다. 펫 이름은 해당 펫의 기본값 또는 이전에 설정한 이름으로 설정됩니다.")
     public ResponseEntity<ApiResponse<PetStatusResponse>> updateMyPet(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody PetUpdateRequest request) {
         PetStatusResponse response = petService.updatePet(userDetails.getUserId(), request);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @PatchMapping("/me/name")
+    @Operation(summary = "내 펫 이름 변경", description = "현재 활성화된 펫의 이름을 변경합니다.")
+    public ResponseEntity<ApiResponse<PetStatusResponse>> updateMyPetName(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody PetNameUpdateRequest request) {
+        PetStatusResponse response = petService.updatePetName(userDetails.getUserId(), request);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 

--- a/src/main/java/com/seasonthon/YEIN/pet/api/dto/request/PetNameUpdateRequest.java
+++ b/src/main/java/com/seasonthon/YEIN/pet/api/dto/request/PetNameUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.seasonthon.YEIN.pet.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PetNameUpdateRequest(
+        @Schema(description = "새로운 펫의 이름", example = "용감한 예인이")
+        @NotBlank(message = "펫 이름은 필수입니다.")
+        @Size(min = 2, max = 10, message = "펫 이름은 2자 이상 10자 이하로 입력해주세요.")
+        String name
+) {}

--- a/src/main/java/com/seasonthon/YEIN/pet/api/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/seasonthon/YEIN/pet/api/dto/request/PetUpdateRequest.java
@@ -2,17 +2,10 @@ package com.seasonthon.YEIN.pet.api.dto.request;
 
 import com.seasonthon.YEIN.pet.domain.PetType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 public record PetUpdateRequest(
-        @Schema(description = "변경할 펫의 종류")
+        @Schema(description = "변경할 펫의 종류", example = "TYPE_1")
         @NotNull(message = "펫 타입을 지정해야 합니다.")
-        PetType petType,
-
-        @Schema(description = "새로운 펫의 이름", example = "용감한 예인이")
-        @NotBlank(message = "펫 이름은 필수입니다.")
-        @Size(min = 2, max = 10, message = "펫 이름은 2자 이상 10자 이하로 입력해주세요.")
-        String name
+        PetType petType
 ) {}

--- a/src/main/java/com/seasonthon/YEIN/pet/domain/PetType.java
+++ b/src/main/java/com/seasonthon/YEIN/pet/domain/PetType.java
@@ -1,9 +1,18 @@
 package com.seasonthon.YEIN.pet.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum PetType {
-    DEFAULT, // 기본 펫
-    TYPE_1,  // 1번 펫
-    TYPE_2,  // 2번 펫
-    TYPE_3,  // 3번 펫
-    TYPE_4   // 4번 펫
+    DEFAULT("예인이"),  // 기본 펫
+    TYPE_1("코코"),    // 1번 펫 
+    TYPE_2("모모"),    // 2번 펫
+    TYPE_3("루루"),    // 3번 펫
+    TYPE_4("토토");    // 4번 펫
+
+    private final String defaultName;
+
+    PetType(String defaultName) {
+        this.defaultName = defaultName;
+    }
 }


### PR DESCRIPTION
# 구현 내용
-  펫 변경 및 이름 변경 API 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 현재 활성 펫 이름 변경 API 추가: PATCH /api/pets/me/name (이름 2~10자, 공백 불가 검증)
  - 펫 타입별 기본 이름 자동 적용
  - DEFAULT 타입으로의 변경 허용
- Documentation
  - PATCH /api/pets/me 엔드포인트 설명 업데이트: 이제 펫 “타입”만 변경되며, 이름은 기본값 또는 기존 값이 유지/자동 설정됨
  - 새 이름 변경 API에 대한 예시와 검증 규칙 명세 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->