### PR TITLE
feat/#79: 커뮤니티 댓글 API 구현

### DIFF
--- a/src/main/java/com/seasonthon/YEIN/comment/api/CommentController.java
+++ b/src/main/java/com/seasonthon/YEIN/comment/api/CommentController.java
@@ -1,0 +1,82 @@
+package com.seasonthon.YEIN.comment.api;
+
+import com.seasonthon.YEIN.comment.api.dto.request.CommentRequest;
+import com.seasonthon.YEIN.comment.api.dto.response.CommentResponse;
+import com.seasonthon.YEIN.comment.api.dto.response.MyCommentResponse;
+import com.seasonthon.YEIN.comment.application.CommentService;
+import com.seasonthon.YEIN.global.code.dto.ApiResponse;
+import com.seasonthon.YEIN.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Comment", description = "댓글 관련 API")
+@RestController
+@RequestMapping("/api/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Operation(summary = "댓글 작성", description = "게시글에 댓글을 작성합니다.")
+    @PostMapping("/posts/{postId}")
+    public ResponseEntity<ApiResponse<Long>> createComment(
+            @Parameter(description = "게시글 ID") @PathVariable Long postId,
+            @Valid @RequestBody CommentRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long commentId = commentService.createComment(postId, request, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(commentId));
+    }
+
+    @Operation(summary = "게시글 댓글 조회", description = "특정 게시글의댓글 목록을 조회합니다.")
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<ApiResponse<Page<CommentResponse>>>
+    findCommentsByPost(
+            @Parameter(description = "게시글 ID") @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Pageable pageable = PageRequest.of(0, 20);
+        Long currentUserId = userDetails != null ? userDetails.getUserId() : null;
+
+        Page<CommentResponse> comments = commentService.findCommentsByPost(postId, pageable, currentUserId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(comments));
+    }
+
+    @Operation(summary = "내 댓글 조회", description = "내가 작성한 댓글 목록을 조회합니다.")
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<Page<MyCommentResponse>>> findMyComments(
+            @Parameter(description = "페이지 번호") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<MyCommentResponse> comments = commentService.findMyComments(userDetails.getUserId(), pageable);
+        return ResponseEntity.ok(ApiResponse.onSuccess(comments));
+    }
+
+    @Operation(summary = "댓글 수정", description = "내가 작성한 댓글을 수정합니다.")
+    @PutMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> updateComment(
+            @Parameter(description = "댓글 ID") @PathVariable Long commentId,
+            @Valid @RequestBody CommentRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        commentService.updateComment(commentId, request, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+    @Operation(summary = "댓글 삭제", description = "내가 작성한 댓글을 삭제합니다.")
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @Parameter(description = "댓글 ID") @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        commentService.deleteComment(commentId, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+}

--- a/src/main/java/com/seasonthon/YEIN/comment/api/CommentController.java
+++ b/src/main/java/com/seasonthon/YEIN/comment/api/CommentController.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -38,11 +37,10 @@ public class CommentController {
 
     @Operation(summary = "게시글 댓글 조회", description = "특정 게시글의댓글 목록을 조회합니다.")
     @GetMapping("/posts/{postId}")
-    public ResponseEntity<ApiResponse<Page<CommentResponse>>>
-    findCommentsByPost(
+    public ResponseEntity<ApiResponse<Page<CommentResponse>>> findCommentsByPost(
             @Parameter(description = "게시글 ID") @PathVariable Long postId,
+            @Parameter(description = "페이징 정보") Pageable pageable,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Pageable pageable = PageRequest.of(0, 20);
         Long currentUserId = userDetails != null ? userDetails.getUserId() : null;
 
         Page<CommentResponse> comments = commentService.findCommentsByPost(postId, pageable, currentUserId);
@@ -52,10 +50,8 @@ public class CommentController {
     @Operation(summary = "내 댓글 조회", description = "내가 작성한 댓글 목록을 조회합니다.")
     @GetMapping("/my")
     public ResponseEntity<ApiResponse<Page<MyCommentResponse>>> findMyComments(
-            @Parameter(description = "페이지 번호") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size,
+            @Parameter(description = "페이징 정보") Pageable pageable,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Pageable pageable = PageRequest.of(page, size);
         Page<MyCommentResponse> comments = commentService.findMyComments(userDetails.getUserId(), pageable);
         return ResponseEntity.ok(ApiResponse.onSuccess(comments));
     }

--- a/src/main/java/com/seasonthon/YEIN/comment/api/dto/request/CommentRequest.java
+++ b/src/main/java/com/seasonthon/YEIN/comment/api/dto/request/CommentRequest.java
@@ -1,0 +1,16 @@
+package com.seasonthon.YEIN.comment.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CommentRequest(
+        @Schema(description = "댓글 내용", example = "좋은 글이네요!")
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        @Size(max = 1000, message = "댓글은 1000자를 넘을 수 없습니다.")
+        String content
+) {
+    public static CommentRequest of(String content) {
+        return new CommentRequest(content);
+    }
+}

--- a/src/main/java/com/seasonthon/YEIN/comment/api/dto/response/CommentResponse.java
+++ b/src/main/java/com/seasonthon/YEIN/comment/api/dto/response/CommentResponse.java
@@ -1,0 +1,41 @@
+package com.seasonthon.YEIN.comment.api.dto.response;
+
+import com.seasonthon.YEIN.comment.domain.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record CommentResponse(
+        @Schema(description = "댓글 ID")
+        Long id,
+
+        @Schema(description = "댓글 내용")
+        String content,
+
+        @Schema(description = "작성자 닉네임")
+        String authorNickname,
+
+        @Schema(description = "작성자 프로필 이미지")
+        String authorProfileImage,
+
+        @Schema(description = "작성일시")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정일시")
+        LocalDateTime updatedAt,
+
+        @Schema(description = "작성자 여부")
+        boolean isOwner
+) {
+    public static CommentResponse from(Comment comment, boolean isOwner) {
+        return new CommentResponse(
+                comment.getId(),
+                comment.getContent(),
+                comment.getUser().getNickname(),
+                comment.getUser().getProfileImageUrl(),
+                comment.getCreatedAt(),
+                comment.getUpdatedAt(),
+                isOwner
+        );
+    }
+}

--- a/src/main/java/com/seasonthon/YEIN/comment/api/dto/response/MyCommentResponse.java
+++ b/src/main/java/com/seasonthon/YEIN/comment/api/dto/response/MyCommentResponse.java
@@ -1,0 +1,33 @@
+package com.seasonthon.YEIN.comment.api.dto.response;
+
+import com.seasonthon.YEIN.comment.domain.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record MyCommentResponse(
+        @Schema(description = "댓글 ID")
+        Long commentId,
+
+        @Schema(description = "댓글 내용")
+        String content,
+
+        @Schema(description = "게시글 ID")
+        Long postId,
+
+        @Schema(description = "게시글 제목")
+        String postTitle,
+
+        @Schema(description = "작성일시")
+        LocalDateTime createdAt
+) {
+    public static MyCommentResponse from(Comment comment) {
+        return new MyCommentResponse(
+                comment.getId(),
+                comment.getContent(),
+                comment.getPost().getId(),
+                comment.getPost().getTitle(),
+                comment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/seasonthon/YEIN/comment/application/CommentService.java
+++ b/src/main/java/com/seasonthon/YEIN/comment/application/CommentService.java
@@ -1,0 +1,100 @@
+package com.seasonthon.YEIN.comment.application;
+
+import com.seasonthon.YEIN.comment.api.dto.request.CommentRequest;
+import com.seasonthon.YEIN.comment.api.dto.response.CommentResponse;
+import com.seasonthon.YEIN.comment.api.dto.response.MyCommentResponse;
+import com.seasonthon.YEIN.comment.domain.Comment;
+import com.seasonthon.YEIN.comment.domain.repository.CommentRepository;
+import com.seasonthon.YEIN.global.code.status.ErrorStatus;
+import com.seasonthon.YEIN.global.exception.GeneralException;
+import com.seasonthon.YEIN.post.domain.Post;
+import com.seasonthon.YEIN.post.domain.repository.PostRepository;
+import com.seasonthon.YEIN.user.domain.User;
+import com.seasonthon.YEIN.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long createComment(Long postId, CommentRequest request, Long userId) {
+        Post post = findPostById(postId);
+        User user = findUserById(userId);
+
+        Comment comment = Comment.builder()
+                .content(request.content())
+                .post(post)
+                .user(user)
+                .build();
+
+        Comment savedComment = commentRepository.save(comment);
+        post.incrementCommentCount();
+
+        return savedComment.getId();
+    }
+
+    public Page<CommentResponse> findCommentsByPost(Long postId, Pageable pageable, Long currentUserId) {
+        findPostById(postId);
+
+        Page<Comment> comments = commentRepository.findByPostIdOrderByCreatedAt(postId, pageable);
+
+        return comments.map(comment -> CommentResponse.from(comment, comment.isOwner(currentUserId)));
+    }
+
+    public Page<MyCommentResponse> findMyComments(Long userId, Pageable pageable) {
+        findUserById(userId);
+
+        Page<Comment> comments = commentRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+
+        return comments.map(MyCommentResponse::from);
+    }
+
+    @Transactional
+    public void updateComment(Long commentId, CommentRequest request, Long userId) {
+        Comment comment = findCommentById(commentId);
+        validateCommentOwner(comment, userId);
+
+        comment.updateContent(request.content());
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId, Long userId) {
+        Comment comment = findCommentById(commentId);
+        validateCommentOwner(comment, userId);
+
+        Post post = comment.getPost();
+        commentRepository.delete(comment);
+        post.decrementCommentCount();
+    }
+
+    private Post findPostById(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    private Comment findCommentById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+    }
+
+    private void validateCommentOwner(Comment comment, Long userId) {
+        if (!comment.isOwner(userId)) {
+            throw new GeneralException(ErrorStatus.ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/com/seasonthon/YEIN/comment/domain/Comment.java
+++ b/src/main/java/com/seasonthon/YEIN/comment/domain/Comment.java
@@ -1,0 +1,47 @@
+package com.seasonthon.YEIN.comment.domain;
+
+import com.seasonthon.YEIN.global.entity.BaseAuditEntity;
+import com.seasonthon.YEIN.post.domain.Post;
+import com.seasonthon.YEIN.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "comments")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseAuditEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    public Comment(String content, Post post, User user) {
+        this.content = content;
+        this.post = post;
+        this.user = user;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public boolean isOwner(Long userId) {
+        return this.user.getId().equals(userId);
+    }
+}

--- a/src/main/java/com/seasonthon/YEIN/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/seasonthon/YEIN/comment/domain/repository/CommentRepository.java
@@ -1,0 +1,25 @@
+package com.seasonthon.YEIN.comment.domain.repository;
+
+import com.seasonthon.YEIN.comment.domain.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT c FROM Comment c " +
+            "JOIN FETCH c.user " +
+            "WHERE c.post.id = :postId " +
+            "ORDER BY c.createdAt ASC")
+    Page<Comment> findByPostIdOrderByCreatedAt(@Param("postId") Long postId, Pageable pageable);
+
+    @Query("SELECT c FROM Comment c " +
+            "JOIN FETCH c.post " +
+            "WHERE c.user.id = :userId " +
+            "ORDER BY c.createdAt DESC")
+    Page<Comment> findByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId, Pageable pageable);
+
+    long countByPostId(Long postId);
+}

--- a/src/main/java/com/seasonthon/YEIN/global/code/status/ErrorStatus.java
+++ b/src/main/java/com/seasonthon/YEIN/global/code/status/ErrorStatus.java
@@ -38,6 +38,7 @@ public enum ErrorStatus implements BaseErrorCode {
     PET_NOT_FOUND(HttpStatus.NOT_FOUND, "PET4044", "펫을 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4045", "게시글을 찾을 수 없습니다."),
     GALLERY_NOT_FOUND(HttpStatus.NOT_FOUND, "GALLERY4046", "갤러리를 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4047", "댓글을 찾을 수 없습니다."),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON405", "허용되지 않는 HTTP 메서드입니다."),

--- a/src/main/java/com/seasonthon/YEIN/post/domain/Post.java
+++ b/src/main/java/com/seasonthon/YEIN/post/domain/Post.java
@@ -1,5 +1,6 @@
 package com.seasonthon.YEIN.post.domain;
 
+import com.seasonthon.YEIN.comment.domain.Comment;
 import com.seasonthon.YEIN.global.entity.BaseAuditEntity;
 import com.seasonthon.YEIN.user.domain.User;
 import jakarta.persistence.*;
@@ -55,6 +56,12 @@ public class Post extends BaseAuditEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Like> likes = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    @Column(name = "comment_count", nullable = false)
+    private Integer commentCount = 0;
+
     @Builder
     public Post(User user, String title, String quote, String author, String imageUrl, String bookTitle) {
         this.user = user;
@@ -97,6 +104,16 @@ public class Post extends BaseAuditEntity {
     public void decrementLikeCount() {
         if (this.likeCount > 0) {
             this.likeCount--;
+        }
+    }
+
+    public void incrementCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decrementCommentCount() {
+        if (this.commentCount > 0) {
+            this.commentCount--;
         }
     }
 }


### PR DESCRIPTION
# 구현 내용
- 커뮤니티 댓글 API 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 게시글에 댓글 작성/조회/수정/삭제 지원 및 댓글 소유자 권한 검사.
  - 게시글별 댓글 목록(페이지네이션, 작성순) 및 내 댓글 목록(페이지네이션, 최신순) 제공.
  - 응답에 작성자 닉네임·프로필, 작성·수정 시간, 소유자 여부 포함.
  - 댓글 생성/삭제 시 게시글의 댓글 수 자동 갱신.

- Documentation
  - 댓글 관련 API를 Swagger로 문서화하고 요청/응답 예시와 검증 규칙 명시.

- Chores
  - 댓글 관련 오류 코드(댓글 미존재) 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->