### PR TITLE
feat/#81: 사용자 프로필 수정 API 구현

### DIFF
--- a/src/main/java/com/seasonthon/YEIN/user/api/UserController.java
+++ b/src/main/java/com/seasonthon/YEIN/user/api/UserController.java
@@ -1,0 +1,42 @@
+package com.seasonthon.YEIN.user.api;
+
+import com.seasonthon.YEIN.global.code.dto.ApiResponse;
+import com.seasonthon.YEIN.global.security.CustomUserDetails;
+import com.seasonthon.YEIN.user.api.dto.request.UpdateProfileRequest;
+import com.seasonthon.YEIN.user.api.dto.response.UpdateProfileResponse;
+import com.seasonthon.YEIN.user.application.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "사용자 API", description = "사용자 프로필 관리")
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "사용자 프로필 수정", description = "닉네임과 프로필 이미지를 선택적으로 수정합니다.")
+    @PatchMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<UpdateProfileResponse>> updateProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestPart(value = "data", required = false) UpdateProfileRequest request,
+            @RequestPart(value = "image", required = false) MultipartFile profileImage) {
+        
+        String nickname = request != null ? request.nickname() : null;
+        
+        UpdateProfileResponse response = userService.updateProfile(userDetails.getUserId(), nickname, profileImage);
+        
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+}

--- a/src/main/java/com/seasonthon/YEIN/user/api/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/seasonthon/YEIN/user/api/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,13 @@
+package com.seasonthon.YEIN.user.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "사용자 프로필 수정 요청")
+public record UpdateProfileRequest(
+        
+        @Schema(description = "닉네임", example = "새로운닉네임")
+        @Size(max = 20, message = "닉네임은 20자 이하여야 합니다.")
+        String nickname
+) {
+}

--- a/src/main/java/com/seasonthon/YEIN/user/api/dto/response/UpdateProfileResponse.java
+++ b/src/main/java/com/seasonthon/YEIN/user/api/dto/response/UpdateProfileResponse.java
@@ -1,0 +1,20 @@
+package com.seasonthon.YEIN.user.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자 프로필 수정 응답")
+public record UpdateProfileResponse(
+        
+        @Schema(description = "사용자 ID", example = "1")
+        Long userId,
+        
+        @Schema(description = "닉네임", example = "새로운닉네임")
+        String nickname,
+        
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String profileImageUrl
+) {
+    public static UpdateProfileResponse from(Long userId, String nickname, String profileImageUrl) {
+        return new UpdateProfileResponse(userId, nickname, profileImageUrl);
+    }
+}

--- a/src/main/java/com/seasonthon/YEIN/user/application/UserService.java
+++ b/src/main/java/com/seasonthon/YEIN/user/application/UserService.java
@@ -1,0 +1,46 @@
+package com.seasonthon.YEIN.user.application;
+
+import com.seasonthon.YEIN.global.code.status.ErrorStatus;
+import com.seasonthon.YEIN.global.exception.GeneralException;
+import com.seasonthon.YEIN.global.s3.S3UploadService;
+import com.seasonthon.YEIN.user.api.dto.response.UpdateProfileResponse;
+import com.seasonthon.YEIN.user.domain.User;
+import com.seasonthon.YEIN.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final S3UploadService s3UploadService;
+
+    @Transactional
+    public UpdateProfileResponse updateProfile(Long userId, String nickname, MultipartFile profileImage) {
+        User user = findUserById(userId);
+        
+        if (nickname != null && !nickname.trim().isEmpty()) {
+            user.updateNickname(nickname);
+        }
+        
+        if (profileImage != null && !profileImage.isEmpty()) {
+            String imageUrl = uploadProfileImage(profileImage);
+            user.updateProfileImage(imageUrl);
+        }
+        
+        return UpdateProfileResponse.from(user.getId(), user.getNickname(), user.getProfileImageUrl());
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    }
+    
+    private String uploadProfileImage(MultipartFile file) {
+        return s3UploadService.uploadFile(file);
+    }
+}


### PR DESCRIPTION
# 구현 기능
- 사용자 닉네임 및 이미지 수정 API 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 사용자 프로필 수정 API 추가: 닉네임 및 프로필 이미지 변경 지원
  - 멀티파트 업로드 지원으로 이미지 파일 업로드 가능
  - 선택적으로 닉네임만 또는 이미지 파일만 수정 가능
  - 인증된 사용자 기준으로 본인 프로필 업데이트 수행
- 개선/문서
  - API 스펙에 설명 및 예시 추가로 Swagger에서 사용성 향상
- 검증
  - 닉네임 길이 제한(최대 20자) 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->