### PR TITLE
feat/#77: 사용자 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/seasonthon/YEIN/gallery/domain/repository/GalleryRepository.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/domain/repository/GalleryRepository.java
@@ -10,12 +10,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 public interface GalleryRepository extends JpaRepository<Gallery, Long> {
 
     Optional<Gallery> findByIdAndUser(Long id, User user);
+
+    List<Gallery> findByUser(User user);
 
     @Query("SELECT g FROM Gallery g " +
             "WHERE g.user = :user " +
@@ -38,4 +41,6 @@ public interface GalleryRepository extends JpaRepository<Gallery, Long> {
             @Param("sortBy") String sortBy,
             Pageable pageable
     );
+
+    long countByUserAndCreatedAtBetween(User user, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/com/seasonthon/YEIN/post/domain/repository/LikeRepository.java
+++ b/src/main/java/com/seasonthon/YEIN/post/domain/repository/LikeRepository.java
@@ -1,6 +1,9 @@
 package com.seasonthon.YEIN.post.domain.repository;
 
 import com.seasonthon.YEIN.post.domain.Like;
+import com.seasonthon.YEIN.post.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +21,7 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     @Query("SELECT l.post.id FROM Like l WHERE l.user.id = :userId AND l.post.id IN :postIds")
     Set<Long> findLikedPostIdsByUserIdAndPostIds(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
+
+    @Query("SELECT l.post FROM Like l WHERE l.user.id = :userId")
+    Page<Post> findLikedPostsByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/seasonthon/YEIN/user/api/UserController.java
+++ b/src/main/java/com/seasonthon/YEIN/user/api/UserController.java
@@ -2,16 +2,19 @@ package com.seasonthon.YEIN.user.api;
 
 import com.seasonthon.YEIN.global.code.dto.ApiResponse;
 import com.seasonthon.YEIN.global.security.CustomUserDetails;
+import com.seasonthon.YEIN.post.api.dto.response.PostListResponse;
+import com.seasonthon.YEIN.post.application.PostService;
 import com.seasonthon.YEIN.user.api.dto.request.UpdateProfileRequest;
 import com.seasonthon.YEIN.user.api.dto.response.UpdateProfileResponse;
+import com.seasonthon.YEIN.user.api.dto.response.UserProfileResponse;
 import com.seasonthon.YEIN.user.application.UserService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,6 +28,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserController {
 
     private final UserService userService;
+    private final PostService postService;
+
 
     @Operation(summary = "사용자 프로필 수정", description = "닉네임과 프로필 이미지를 선택적으로 수정합니다.")
     @PatchMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -32,11 +37,30 @@ public class UserController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestPart(value = "data", required = false) UpdateProfileRequest request,
             @RequestPart(value = "image", required = false) MultipartFile profileImage) {
-        
+
         String nickname = request != null ? request.nickname() : null;
-        
+
         UpdateProfileResponse response = userService.updateProfile(userDetails.getUserId(), nickname, profileImage);
-        
+
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "내 프로필 조회", description = "로그인한 사용자의 프로필 정보를 조회합니다. 이메일, 총 필사 수, 평균 필사 점수 등을 포함합니다.")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> getMyProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        UserProfileResponse response = userService.getUserProfile(userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @GetMapping("/me/liked-posts")
+    @Operation(summary = "내가 추천한 게시글 목록 조회", description = "로그인한 사용자가 추천(좋아요)한 게시글 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<Page<PostListResponse>>> getMyLikedPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "페이징 정보")
+            Pageable pageable) {
+        Page<PostListResponse> response = postService.getLikedPosts(userDetails.getUserId(), pageable);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+
     }
 }

--- a/src/main/java/com/seasonthon/YEIN/user/api/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/seasonthon/YEIN/user/api/dto/response/UserProfileResponse.java
@@ -1,0 +1,14 @@
+package com.seasonthon.YEIN.user.api.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record UserProfileResponse(
+        Long userId,
+        String email,
+        String nickname,
+        String profileImageUrl,
+        double averageHandwritingScore, // 평균 필사 점수
+        int totalGalleries, // 총 필사 수
+        int todayGalleries // 오늘 작성한 필사 수
+) {}

--- a/src/main/java/com/seasonthon/YEIN/user/application/UserService.java
+++ b/src/main/java/com/seasonthon/YEIN/user/application/UserService.java
@@ -1,9 +1,12 @@
 package com.seasonthon.YEIN.user.application;
 
+import com.seasonthon.YEIN.gallery.domain.Gallery;
+import com.seasonthon.YEIN.gallery.domain.repository.GalleryRepository;
 import com.seasonthon.YEIN.global.code.status.ErrorStatus;
 import com.seasonthon.YEIN.global.exception.GeneralException;
 import com.seasonthon.YEIN.global.s3.S3UploadService;
 import com.seasonthon.YEIN.user.api.dto.response.UpdateProfileResponse;
+import com.seasonthon.YEIN.user.api.dto.response.UserProfileResponse;
 import com.seasonthon.YEIN.user.domain.User;
 import com.seasonthon.YEIN.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,12 +14,17 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
 
     private final UserRepository userRepository;
+    private final GalleryRepository galleryRepository;
     private final S3UploadService s3UploadService;
 
     @Transactional
@@ -34,6 +42,34 @@ public class UserService {
         
         return UpdateProfileResponse.from(user.getId(), user.getNickname(), user.getProfileImageUrl());
     }
+
+    public UserProfileResponse getUserProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        List<Gallery> userGalleries = galleryRepository.findByUser(user);
+        double averageScore = userGalleries.stream()
+                .mapToDouble(Gallery::getTotalScore)
+                .average()
+                .orElse(0.0);
+
+        // Calculate today's galleries
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(23, 59, 59, 999999999);
+        long todayGalleries = galleryRepository.countByUserAndCreatedAtBetween(user, startOfDay, endOfDay);
+
+        return UserProfileResponse.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
+                .averageHandwritingScore(Math.round(averageScore * 100.0) / 100.0)
+                .totalGalleries(userGalleries.size())
+                .todayGalleries((int) todayGalleries)
+                .build();
+    }
+
 
     private User findUserById(Long userId) {
         return userRepository.findById(userId)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 내 프로필 조회 제공: 사용자 정보와 평균 손글씨 점수, 전체/오늘 갤러리 수를 포함해 반환.
  - 내가 좋아요한 게시글 목록 제공: 페이지네이션 지원, 각 게시글의 좋아요/스크랩 상태를 함께 표시하며 페이지 정보 포함.

- 개선
  - 프로필 수정 응답을 공통 응답 형식으로 정렬하여 API 응답 일관성 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->