### PR TITLE
fix/#84: 필사 갤러리 필터링 한국 시간대로 변경

### DIFF
--- a/src/main/java/com/seasonthon/YEIN/YeinApplication.java
+++ b/src/main/java/com/seasonthon/YEIN/YeinApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")
+@EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl", dateTimeProviderRef = "dateTimeProvider")
 public class YeinApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/seasonthon/YEIN/gallery/application/GalleryService.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/application/GalleryService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @Service
 @RequiredArgsConstructor
@@ -35,7 +36,7 @@ public class GalleryService {
         Page<Gallery> galleries = galleryRepository.findGalleriesWithDynamicSort(
                 user,
                 startDate,
-                LocalDateTime.now(),
+                LocalDateTime.now(ZoneId.of("Asia/Seoul")),
                 minScore,
                 maxScore,
                 sortBy,
@@ -69,11 +70,13 @@ public class GalleryService {
 
     private LocalDateTime calculateStartDate(String period) {
         if (period == null) return null;
+        
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
 
         return switch (period.toLowerCase()) {
-            case "today" -> LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
-            case "week" -> LocalDateTime.now().minusWeeks(1);
-            case "month" -> LocalDateTime.now().minusMonths(1);
+            case "today" -> now.withHour(0).withMinute(0).withSecond(0).withNano(0);
+            case "week" -> now.minusWeeks(1);
+            case "month" -> now.minusMonths(1);
             case "all" -> null;
             default -> null;
         };

--- a/src/main/java/com/seasonthon/YEIN/gallery/domain/repository/GalleryRepository.java
+++ b/src/main/java/com/seasonthon/YEIN/gallery/domain/repository/GalleryRepository.java
@@ -1,7 +1,6 @@
 package com.seasonthon.YEIN.gallery.domain.repository;
 
 import com.seasonthon.YEIN.gallery.domain.Gallery;
-import com.seasonthon.YEIN.gallery.domain.MoodTag;
 import com.seasonthon.YEIN.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,7 +10,6 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
-import java.util.Set;
 
 public interface GalleryRepository extends JpaRepository<Gallery, Long> {
 

--- a/src/main/java/com/seasonthon/YEIN/global/config/JpaConfig.java
+++ b/src/main/java/com/seasonthon/YEIN/global/config/JpaConfig.java
@@ -1,0 +1,18 @@
+package com.seasonthon.YEIN.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+@Configuration
+public class JpaConfig {
+
+    @Bean
+    public DateTimeProvider dateTimeProvider() {
+        return () -> Optional.of(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,9 @@ server:
 
 spring:
   profiles:
-    active: prod
+    active: local
+  jackson:
+    time-zone: Asia/Seoul
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:9roomthon}
@@ -17,6 +19,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
     show-sql: true
     open-in-view: false
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ server:
 
 spring:
   profiles:
-    active: local
+    active: prod
   jackson:
     time-zone: Asia/Seoul
   datasource:


### PR DESCRIPTION
# 수정 내용
- 필사 갤러리 필터링 한국 시간대로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 갤러리 날짜 필터(오늘/이번 주/이번 달)가 한국 시간(Asia/Seoul) 기준으로 정확히 동작합니다.
  - 생성/수정 시각이 한국 시간 기준으로 일관되게 기록·표시됩니다.
- 개선
  - 애플리케이션 전역 시간대를 Asia/Seoul로 통일해 날짜·시간 표시 일관성 향상.
  - JPA 감사 시각 소스를 한국 시간 제공자로 명시적으로 연결.
- Chores
  - 불필요한 임포트 정리 및 구성 정리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->